### PR TITLE
feat(1.1-product): add Product model, migration, and basic tests

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,0 +1,7 @@
+class Product < ApplicationRecord
+  belongs_to :created_by_user, class_name: "User"
+
+    validates :sku, presence: true, uniqueness: true
+    validates :name, presence: true
+    validates :price, numericality: { greater_than_or_equal_to: 0 }, unless: :is_bundle?
+end

--- a/db/migrate/20250930141517_create_products.rb
+++ b/db/migrate/20250930141517_create_products.rb
@@ -1,0 +1,16 @@
+class CreateProducts < ActiveRecord::Migration[7.2]
+  def change
+    create_table :products do |t|
+      t.string :sku
+      t.string :name
+      t.text :description
+      t.decimal :price, precision: 10, scale: 2
+      t.boolean :is_bundle, default: false
+      t.jsonb :metadata, default: {}
+      t.references :created_by_user, null: false, foreign_key: { to_table: :users }
+
+      t.timestamps
+    end
+    add_index :products, :sku, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_29_133935) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_30_141517) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "products", force: :cascade do |t|
+    t.string "sku"
+    t.string "name"
+    t.text "description"
+    t.decimal "price", precision: 10, scale: 2
+    t.boolean "is_bundle", default: false
+    t.jsonb "metadata", default: {}
+    t.bigint "created_by_user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["created_by_user_id"], name: "index_products_on_created_by_user_id"
+    t.index ["sku"], name: "index_products_on_sku", unique: true
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -29,4 +43,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_29_133935) do
     t.index ["jti"], name: "index_users_on_jti", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  add_foreign_key "products", "users", column: "created_by_user_id"
 end

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :product do
+    sku { "MyString" }
+    name { "MyString" }
+    description { "MyText" }
+    price { "9.99" }
+    is_bundle { false }
+    metadata { "" }
+    created_by_user { nil }
+  end
+end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe Product, type: :model do
+  let(:user) { User.create!(name: "Test User", email: "test@example.com", password: "password") }
+
+  subject do
+    described_class.new(
+      sku: "SKU123",
+      name: "Sample Product",
+      description: "A sample product",
+      price: 100.50,
+      is_bundle: false,
+      metadata: { color: "red" },
+      created_by_user: user
+    )
+  end
+
+  describe "validations" do
+    it "is valid with valid attributes" do
+      expect(subject).to be_valid
+    end
+
+    it "is not valid without a sku" do
+      subject.sku = nil
+      expect(subject).to_not be_valid
+      expect(subject.errors[:sku]).to include("can't be blank")
+    end
+
+    it "is not valid with duplicate sku" do
+      described_class.create!(
+        sku: "SKU123",
+        name: "Another Product",
+        price: 50,
+        is_bundle: false,
+        created_by_user: user
+      )
+      expect(subject).not_to be_valid
+      expect(subject.errors[:sku]).to include("has already been taken")
+    end
+
+    it "is not valid without a name" do
+      subject.name = nil
+      expect(subject).not_to be_valid
+    end
+
+    it "is not valid with negative price" do
+      subject.price = -10
+      expect(subject).not_to be_valid
+    end
+  end
+
+  describe "associations" do
+    it "belongs to created_by_user" do
+      assoc = described_class.reflect_on_association(:created_by_user)
+      expect(assoc.macro).to eq(:belongs_to)
+    end
+  end
+end


### PR DESCRIPTION
## Overview
This PR sets up the Product model and its database table as part of Ticket 1.1.

### Changes
- Added `Product` model with the following fields:
  - `sku` (unique)
  - `name`
  - `description`
  - `price` (decimal)
  - `is_bundle` (boolean)
  - `metadata` (jsonb)
  - `created_by_user` (foreign key to Users)
  - timestamps
- Added migration with unique index on `sku`
- Added validations (e.g., presence, uniqueness)
- Added basic RSpec tests for model associations

### Next Steps
- Add bundle-related associations and tests
- Implement Products API endpoints (GET / POST)
