### PR TITLE
feat: Add InventoryLocation model with warehouse association and uniq…

### DIFF
--- a/app/models/inventory_location.rb
+++ b/app/models/inventory_location.rb
@@ -1,0 +1,19 @@
+class InventoryLocation < ApplicationRecord
+  belongs_to :warehouse
+  has_many :products, dependent: :nullify
+
+  validates :storage_id, presence: true
+  validates :unique_item_limits, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
+  validates :capacity, numericality: { greater_than_or_equal_to: 100 }, allow_nil: true
+  validate :respect_unique_item_limits
+
+  private
+
+  def respect_unique_item_limits
+    return if unique_item_limits.nil?
+
+    if products.distinct.count > unique_item_limits
+      errors.add(:products, "exceeds the unique item limit of #{unique_item_limits}")
+    end
+  end
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -3,7 +3,7 @@ class Product < ApplicationRecord
   belongs_to :created_by_user, class_name: "User"
 
   validates :sku, presence: true, uniqueness: true
-
+  validate :respect_location_unique_item_limits
   validates :name, presence: true
   validates :price, numericality: { greater_than_or_equal_to: 0 }, unless: :is_bundle?
 
@@ -12,6 +12,7 @@ class Product < ApplicationRecord
 
   has_many :inverse_bundled_products, class_name: "BundledProduct", foreign_key: :component_id, dependent: :destroy
   has_many :bundles, through: :inverse_bundled_products, source: :bundle
+  belongs_to :inventory_location
 
   private
 
@@ -25,10 +26,23 @@ class Product < ApplicationRecord
     base_sku = prefix + last_letter
 
     if Product.exists?(sku: base_sku)
-      errors.add(:base, "Product with this name or SKU already exists")
+      errors.add(:base, "Product with this name or SKU #{base_sku} already exists")
       throw(:abort)  # <---- stops creation
     end
 
     self.sku = base_sku
+  end
+
+  def respect_location_unique_item_limits
+    return if inventory_location.nil?
+    return if inventory_location.unique_item_limits.nil?
+
+    current_unique_count = inventory_location.products.distinct.count
+    # If this is a new record, it hasn’t been counted yet → add 1
+    current_unique_count += 1 if new_record?
+
+    if current_unique_count > inventory_location.unique_item_limits
+      errors.add(:inventory_location, "has reached its unique product limit of #{inventory_location.unique_item_limits}")
+    end
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -26,7 +26,7 @@ class Product < ApplicationRecord
     base_sku = prefix + last_letter
 
     if Product.exists?(sku: base_sku)
-      errors.add(:base, "Product with this name or SKU #{base_sku} already exists")
+      errors.add(:base, "Product with this name or SKU already exists")
       throw(:abort)  # <---- stops creation
     end
 

--- a/app/models/warehouse.rb
+++ b/app/models/warehouse.rb
@@ -1,3 +1,6 @@
 class Warehouse < ApplicationRecord
     has_many :inventory_locations, dependent: :destroy
+
+    validates :name, presence: true
+    validates :address, presence: true
 end

--- a/app/models/warehouse.rb
+++ b/app/models/warehouse.rb
@@ -1,0 +1,3 @@
+class Warehouse < ApplicationRecord
+    has_many :inventory_locations, dependent: :destroy
+end

--- a/db/migrate/20251004144224_create_warehouses.rb
+++ b/db/migrate/20251004144224_create_warehouses.rb
@@ -1,0 +1,10 @@
+class CreateWarehouses < ActiveRecord::Migration[7.2]
+  def change
+    create_table :warehouses do |t|
+      t.string :name, null: false
+      t.string :address, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20251004144640_create_inventory_locations.rb
+++ b/db/migrate/20251004144640_create_inventory_locations.rb
@@ -1,0 +1,12 @@
+class CreateInventoryLocations < ActiveRecord::Migration[7.2]
+  def change
+    create_table :inventory_locations do |t|
+      t.string :storage_id
+      t.integer :unique_item_limits
+      t.integer :capacity, default: 100
+      t.references :warehouse, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20251004152514_add_inventory_location_to_products.rb
+++ b/db/migrate/20251004152514_add_inventory_location_to_products.rb
@@ -1,0 +1,5 @@
+class AddInventoryLocationToProducts < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :products, :inventory_location, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_10_04_072740) do
+ActiveRecord::Schema[7.2].define(version: 2025_10_04_152514) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -25,6 +25,16 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_04_072740) do
     t.index ["component_id"], name: "index_bundled_products_on_component_id"
   end
 
+  create_table "inventory_locations", force: :cascade do |t|
+    t.string "storage_id"
+    t.integer "unique_item_limits"
+    t.integer "capacity", default: 100
+    t.bigint "warehouse_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["warehouse_id"], name: "index_inventory_locations_on_warehouse_id"
+  end
+
   create_table "products", force: :cascade do |t|
     t.string "sku"
     t.string "name"
@@ -35,7 +45,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_04_072740) do
     t.bigint "created_by_user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "inventory_location_id", null: false
     t.index ["created_by_user_id"], name: "index_products_on_created_by_user_id"
+    t.index ["inventory_location_id"], name: "index_products_on_inventory_location_id"
     t.index ["sku"], name: "index_products_on_sku", unique: true
   end
 
@@ -55,7 +67,16 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_04_072740) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  create_table "warehouses", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "address", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   add_foreign_key "bundled_products", "products", column: "bundle_id"
   add_foreign_key "bundled_products", "products", column: "component_id"
+  add_foreign_key "inventory_locations", "warehouses"
+  add_foreign_key "products", "inventory_locations"
   add_foreign_key "products", "users", column: "created_by_user_id"
 end

--- a/spec/factories/inventory_locations.rb
+++ b/spec/factories/inventory_locations.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :inventory_location do
+    storage_id { "MyString" }
+    unique_item_limits { 1 }
+    warehouse { nil }
+  end
+end

--- a/spec/factories/warehouses.rb
+++ b/spec/factories/warehouses.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :warehouse do
+    name { "MyString" }
+    address { "MyString" }
+  end
+end

--- a/spec/models/bundled_product_spec.rb
+++ b/spec/models/bundled_product_spec.rb
@@ -1,15 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe BundledProduct, type: :model do
-  describe "asspciations" do
+  describe "associations" do
     it { should belong_to(:bundle).class_name('Product') }
     it { should belong_to(:component).class_name('Product') }
   end
 
   describe "validations" do
+    let(:warehouse) { Warehouse.create!(name: "Main Warehouse", address: "1234 Main St") }
+    let(:location) { InventoryLocation.create!(storage_id: "LOC-001", capacity: 100, warehouse: warehouse) }
     let(:user) { User.create!(name: "Test User", email: "test@example.com", password: "password") }
-    let(:bundle) { Product.create!(sku: "BUNDLE1", name: "Bundle Product", is_bundle: true, price: 10, created_by_user: user) }
-    let(:component) { Product.create!(sku: "COMP1", name: "Component Product", is_bundle: false, price: 5, created_by_user: user) }
+    let(:bundle) { Product.create!(name: "Bundle Product", is_bundle: true, price: 10, created_by_user: user, inventory_location: location) }
+    let(:component) { Product.create!(name: "Component Product", is_bundle: false, price: 5, created_by_user: user, inventory_location: location) }
 
     it "is valid with bundle and component" do
       bundled_product = BundledProduct.new(bundle: bundle, component: component, quantity: 2)
@@ -22,13 +24,13 @@ RSpec.describe BundledProduct, type: :model do
     end
 
     it "is invalid if bundle is not a bundle product" do
-      not_a_bundle = Product.create!(sku: "NOTBUNDLE", name: "Not a Bundle", is_bundle: false, price: 5, created_by_user: user)
+      not_a_bundle = Product.create!(name: "Not a Bundle", is_bundle: false, price: 5, created_by_user: user, inventory_location: location)
       bundled_product = BundledProduct.new(bundle: not_a_bundle, component: component, quantity: 2)
       expect(bundled_product).not_to be_valid
     end
 
     it "is invalid if component is a bundle product" do
-      component = Product.create!(sku: "COMPBUNDLE", name: "Component Bundle", is_bundle: true, price: 15, created_by_user: user)
+      component = Product.create!(name: "Component Bundle", is_bundle: true, price: 15, created_by_user: user, inventory_location: location)
       bundled_product = BundledProduct.new(bundle: bundle, component: component, quantity: 2)
       expect(bundled_product).not_to be_valid
     end

--- a/spec/models/inventory_location_spec.rb
+++ b/spec/models/inventory_location_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.describe InventoryLocation, type: :model do
+  let(:warehouse) { Warehouse.create(name: "Pune", address: "1234 Street") }
+  let(:user) { User.create!(name: "Tester", email: "tester@example.com", password: "password") }
+
+  subject {
+    InventoryLocation.new(
+      storage_id: "BIN-001",
+      unique_item_limits: 5,
+      capacity: 150,
+      warehouse: warehouse
+    )
+  }
+
+  describe "associations" do
+    it { should belong_to(:warehouse) }
+    it { should have_many(:products).dependent(:nullify) }
+  end
+
+  describe "validations" do
+    it "is valid with valid attributes" do
+      expect(subject).to be_valid
+    end
+
+    it "is not valid without a warehouse" do
+      subject.warehouse = nil
+      expect(subject).not_to be_valid
+      expect(subject.errors[:warehouse]).to include("must exist")
+    end
+
+    it "is not valid with negative capacity" do
+      subject.capacity = -10
+      expect(subject).not_to be_valid
+    end
+
+    it "is not valid with zero capacity" do
+      subject.capacity = 0
+      expect(subject).not_to be_valid
+    end
+
+    it "is valid if capacity is nil (optional)" do
+      subject.capacity = nil
+      expect(subject).to be_valid
+    end
+
+    it "is not valid with negative unique_item_limits" do
+      subject.unique_item_limits = -2
+      expect(subject).not_to be_valid
+    end
+
+    it "is not valid with zero unique_item_limits" do
+      subject.unique_item_limits = 0
+      expect(subject).not_to be_valid
+    end
+
+    it "is valid if unique_item_limits is nil (optional)" do
+      subject.unique_item_limits = nil
+      expect(subject).to be_valid
+    end
+
+    it "does not allow more unique products than unique_item_limits" do
+      # Add 2 unique products → OK
+      p1 = Product.create!(name: "Laptop", price: 10, created_by_user: user, inventory_location: subject)
+      p2 = Product.create!(name: "Tea", price: 20, created_by_user: user, inventory_location: subject)
+      p3 = Product.create!(name: "Watch", price: 10, created_by_user: user, inventory_location: subject)
+      p4 = Product.create!(name: "Bag", price: 20, created_by_user: user, inventory_location: subject)
+      p5 = Product.create!(name: "Hoodie", price: 10, created_by_user: user, inventory_location: subject)
+      expect(subject.reload).to be_valid
+
+      # Try to add a 3rd unique product → should fail
+      p6 = Product.new(name: "Shoes", price: 30, created_by_user: user, inventory_location: subject)
+      expect(p6.save).to be false
+      expect(p6.errors[:inventory_location]).to include("has reached its unique product limit of 5")
+    end
+  end
+end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 RSpec.describe Product, type: :model do
   let(:user) { User.create!(name: "Test User", email: "test@example.com", password: "password") }
-
+  let(:warehouse) { Warehouse.create!(name: "Main Warehouse", address: "1234 Main St") }
+  let(:location) { InventoryLocation.create!(storage_id: "LOC-001", capacity: 100, warehouse: warehouse) }
   subject do
     described_class.new(
       name: "Sample Product",
@@ -10,7 +11,8 @@ RSpec.describe Product, type: :model do
       price: 100.50,
       is_bundle: false,
       metadata: { color: "red" },
-      created_by_user: user
+      created_by_user: user,
+      inventory_location: location
     )
   end
 
@@ -54,7 +56,8 @@ RSpec.describe Product, type: :model do
         name: "Coffee",
         price: 10,
         is_bundle: false,
-        created_by_user: user
+        created_by_user: user,
+        inventory_location: location
       )
       expect(product.sku.length).to eq(8)
       expect(product.sku).to match(/[A-Z0-9]{8}/)
@@ -66,7 +69,8 @@ RSpec.describe Product, type: :model do
         name: "Coffee",
         price: 10,
         is_bundle: false,
-        created_by_user: user
+        created_by_user: user,
+        inventory_location: location
       )
 
       # Second product with same name should fail
@@ -74,7 +78,8 @@ RSpec.describe Product, type: :model do
         name: "Coffee",
         price: 15,
         is_bundle: false,
-        created_by_user: user
+        created_by_user: user,
+        inventory_location: location
       )
 
       expect(second).not_to be_valid

--- a/spec/models/warehouse_spec.rb
+++ b/spec/models/warehouse_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Warehouse, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/warehouse_spec.rb
+++ b/spec/models/warehouse_spec.rb
@@ -1,5 +1,27 @@
 require 'rails_helper'
 
 RSpec.describe Warehouse, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  subject { described_class.new(name: "Main Warehouse", address: "1234 Street, City") }
+
+  describe "associations" do
+    it { should have_many(:inventory_locations).dependent(:destroy) }
+  end
+
+  describe "validations" do
+    it "is valid with a name and address" do
+      expect(subject).to be_valid
+    end
+
+    it "is not valid without a name" do
+      subject.name = nil
+      expect(subject).not_to be_valid
+      expect(subject.errors[:name]).to include("can't be blank")
+    end
+
+    it "is not valid without an address" do
+      subject.address = nil
+      expect(subject).not_to be_valid
+      expect(subject.errors[:address]).to include("can't be blank")
+    end
+  end
 end


### PR DESCRIPTION
# Feature 1.3: Inventory Locations

## Summary
This PR introduces the `InventoryLocation` model to manage storage bins within warehouses and enforces limits on the number of unique products per location. It also updates the `Product` model to associate each product with a specific inventory location.

## Changes
- Created `InventoryLocation` model with fields:
  - `storage_id` (string, required)
  - `capacity` (integer, optional, must be ≥ 100)
  - `unique_item_limits` (integer, optional, must be > 0)
  - `warehouse_id` (FK → `Warehouse`)
- Added associations:
  - `belongs_to :warehouse`
  - `has_many :products` (dependent: nullify)
- Added validations:
  - `storage_id` presence
  - `capacity` numerical ≥ 100 (if present)
  - `unique_item_limits` numerical > 0 (if present)
  - Custom validation: prevents adding more unique products than `unique_item_limits`
- Updated `Product` model:
  - Added `belongs_to :inventory_location`
  - Added validation to enforce unique product limits per location
- Added RSpec tests for:
  - Associations (`belongs_to`, `has_many`)
  - Validations (presence, numericality, unique item limits)
