### PR TITLE
Add InventoryStatus model with predefined statuses and association to…

### DIFF
--- a/app/models/inventory_status.rb
+++ b/app/models/inventory_status.rb
@@ -1,0 +1,8 @@
+class InventoryStatus < ApplicationRecord
+    has_many :inventory_summaries, dependent: :nullify
+
+    validates :name, presence: true, uniqueness: true, inclusion: {
+        in: %w[Sellable Unsellable Damaged],
+        message: "%{value} is not a valid inventory status"
+    }
+end

--- a/app/models/inventory_summary.rb
+++ b/app/models/inventory_summary.rb
@@ -1,6 +1,7 @@
 class InventorySummary < ApplicationRecord
   belongs_to :product
   belongs_to :inventory_location
+  belongs_to :inventory_status
 
   validates :product, presence: true
   validates :inventory_location, presence: true

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -14,6 +14,7 @@ class Product < ApplicationRecord
   has_many :bundles, through: :inverse_bundled_products, source: :bundle
   belongs_to :inventory_location
 
+
   private
 
   def generate_sku

--- a/db/migrate/20251006130001_create_inventory_statuses.rb
+++ b/db/migrate/20251006130001_create_inventory_statuses.rb
@@ -1,0 +1,10 @@
+class CreateInventoryStatuses < ActiveRecord::Migration[7.2]
+  def change
+    create_table :inventory_statuses do |t|
+      t.string :name
+
+      t.timestamps
+    end
+    add_index :inventory_statuses, :name, unique: true
+  end
+end

--- a/db/migrate/20251006132727_add_inventory_status_to_inventory_summaries.rb
+++ b/db/migrate/20251006132727_add_inventory_status_to_inventory_summaries.rb
@@ -1,0 +1,5 @@
+class AddInventoryStatusToInventorySummaries < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :inventory_summaries, :inventory_status, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_10_05_103610) do
+ActiveRecord::Schema[7.2].define(version: 2025_10_06_132727) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -46,6 +46,13 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_05_103610) do
     t.index ["inventory_summary_id"], name: "index_inventory_movements_on_inventory_summary_id"
   end
 
+  create_table "inventory_statuses", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_inventory_statuses_on_name", unique: true
+  end
+
   create_table "inventory_summaries", force: :cascade do |t|
     t.bigint "product_id", null: false
     t.bigint "inventory_location_id", null: false
@@ -53,7 +60,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_05_103610) do
     t.integer "reserved_quantity"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "inventory_status_id", null: false
     t.index ["inventory_location_id"], name: "index_inventory_summaries_on_inventory_location_id"
+    t.index ["inventory_status_id"], name: "index_inventory_summaries_on_inventory_status_id"
     t.index ["product_id"], name: "index_inventory_summaries_on_product_id"
   end
 
@@ -104,6 +113,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_05_103610) do
   add_foreign_key "inventory_movements", "inventory_summaries"
   add_foreign_key "inventory_movements", "products", column: "bundle_id"
   add_foreign_key "inventory_summaries", "inventory_locations"
+  add_foreign_key "inventory_summaries", "inventory_statuses"
   add_foreign_key "inventory_summaries", "products"
   add_foreign_key "products", "inventory_locations"
   add_foreign_key "products", "users", column: "created_by_user_id"

--- a/spec/factories/inventory_statuses.rb
+++ b/spec/factories/inventory_statuses.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :inventory_status do
+    name { "MyString" }
+  end
+end

--- a/spec/models/inventory_movement_spec.rb
+++ b/spec/models/inventory_movement_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe InventoryMovement, type: :model do
     let(:location2) { InventoryLocation.create!(storage_id: "BIN-02", warehouse: warehouse, capacity: 300) }
     let(:user) { User.create!(name: "User1", email: "a@b.com", password: "123456") }
     let(:product) { Product.create!(name: "Coffee", price: 10, created_by_user: user, inventory_location: location1) }
-    let(:summary) { InventorySummary.create!(product: product, inventory_location: location1, quantity_on_hand: 10, reserved_quantity: 0) }
+    let(:status) { InventoryStatus.create!(name: "Sellable") }
+    let(:summary) { InventorySummary.create!(product: product, inventory_location: location1, inventory_status: status, quantity_on_hand: 10, reserved_quantity: 0) }
 
     subject do
       described_class.new(

--- a/spec/models/inventory_status_spec.rb
+++ b/spec/models/inventory_status_spec.rb
@@ -1,0 +1,98 @@
+# spec/models/inventory_status_spec.rb
+require 'rails_helper'
+
+RSpec.describe InventoryStatus, type: :model do
+  subject { described_class.new(name: "Sellable") }
+
+  describe "validations" do
+    it "is valid with a proper name" do
+      expect(subject).to be_valid
+    end
+
+    it "is not valid without a name" do
+      subject.name = nil
+      expect(subject).not_to be_valid
+      expect(subject.errors[:name]).to include("can't be blank")
+    end
+
+    it "is not valid with an invalid name" do
+      subject.name = "InvalidStatus"
+      expect(subject).not_to be_valid
+      expect(subject.errors[:name]).to include("InvalidStatus is not a valid inventory status")
+    end
+
+    it "enforces uniqueness of name" do
+      described_class.create!(name: "Sellable")
+      expect(subject).not_to be_valid
+      expect(subject.errors[:name]).to include("has already been taken")
+    end
+  end
+
+  describe "associations" do
+    it { should have_many(:inventory_summaries).dependent(:nullify) }
+  end
+end
+
+# spec/models/inventory_summary_spec.rb
+require 'rails_helper'
+
+RSpec.describe InventorySummary, type: :model do
+  let(:user) { User.create!(name: "Tester", email: "test@example.com", password: "password") }
+  let(:warehouse) { Warehouse.create!(name: "Main", address: "123 St") }
+  let(:location) { InventoryLocation.create!(storage_id: "BIN-01", warehouse: warehouse) }
+  let(:product) { Product.create!(name: "Coffee", price: 10, created_by_user: user, inventory_location: location) }
+  let(:status) { InventoryStatus.create!(name: "Sellable") }
+
+  subject do
+    described_class.new(
+      product: product,
+      inventory_location: location,
+      inventory_status: status,
+      quantity_on_hand: 50,
+      reserved_quantity: 5
+    )
+  end
+
+  describe "validations" do
+    it "is valid with all attributes" do
+      expect(subject).to be_valid
+    end
+
+    it "is not valid without a product" do
+      subject.product = nil
+      expect(subject).not_to be_valid
+    end
+
+    it "is not valid without an inventory_location" do
+      subject.inventory_location = nil
+      expect(subject).not_to be_valid
+    end
+
+    it "is not valid without an inventory_status" do
+      subject.inventory_status = nil
+      expect(subject).not_to be_valid
+    end
+
+    it "is not valid if quantity_on_hand is negative" do
+      subject.quantity_on_hand = -1
+      expect(subject).not_to be_valid
+    end
+
+    it "is not valid if reserved_quantity is negative" do
+      subject.reserved_quantity = -1
+      expect(subject).not_to be_valid
+    end
+
+    it "is not valid if reserved_quantity exceeds quantity_on_hand" do
+      subject.reserved_quantity = 100
+      expect(subject).not_to be_valid
+      expect(subject.errors[:reserved_quantity]).to include("cannot exceed quantity on hand")
+    end
+  end
+
+  describe "associations" do
+    it { should belong_to(:product) }
+    it { should belong_to(:inventory_location) }
+    it { should belong_to(:inventory_status) }
+  end
+end

--- a/spec/models/inventory_summary_spec.rb
+++ b/spec/models/inventory_summary_spec.rb
@@ -5,11 +5,13 @@ RSpec.describe InventorySummary, type: :model do
   let(:user) { User.create!(name: "Tester", email: "tester@example.com", password: "password") }
   let(:inventory_location) { InventoryLocation.create!(storage_id: "AEC-01", warehouse: warehouse, capacity: 500, unique_item_limits: 12) }
   let(:product) { Product.create!(name: "Test Product", price: 20.0, created_by_user: user, inventory_location: inventory_location) }
+  let(:status) { InventoryStatus.create!(name: "Sellable") }
 
   subject do
     described_class.new(
       product: product,
       inventory_location: inventory_location,
+      inventory_status: status,
       quantity_on_hand: 10,
       reserved_quantity: 2
     )
@@ -28,6 +30,11 @@ RSpec.describe InventorySummary, type: :model do
     it "is not valid without an inventory location" do
       subject.inventory_location = nil
       is_expected.to_not be_valid
+    end
+
+    it "is not valid without an inventory_status" do
+      subject.inventory_status = nil
+      expect(subject).not_to be_valid
     end
 
     it "is not valid without quantity_on_hand" do
@@ -49,5 +56,11 @@ RSpec.describe InventorySummary, type: :model do
       subject.reserved_quantity = 15
       is_expected.to_not be_valid
     end
+  end
+
+  describe "associations" do
+    it { should belong_to(:product) }
+    it { should belong_to(:inventory_location) }
+    it { should belong_to(:inventory_status) }
   end
 end


### PR DESCRIPTION
# Feature: Inventory Status 

### Summary
This PR introduces the InventoryStatus model to manage the status of inventory items.

- **InventoryStatus:** Tracks the status (Sellable, Unsellable, Damaged) for each InventorySummary item.
- Associations:
  - InventoryStatus belongs_to InventorySummary
- Validations ensure presence, uniqueness, and only allowed statuses are used.
- Includes RSpec tests for validations and model associations.

### Impact
Provides a clear and controlled way to track inventory item statuses per location, supporting reporting and operational workflows.
