### PR TITLE
Feature: Implement Product show endpoint with detailed response and a…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,10 @@ group :development, :test do
   gem "shoulda-matchers"
   # Pry for debugging in console
   gem "pry-rails"
+
+  gem "rswag-api"
+  gem "rswag-ui"
+  gem "rswag-specs"
 end
 
 # -------------------

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -439,6 +439,9 @@ DEPENDENCIES
   rails (~> 7.2.2, >= 7.2.2.1)
   rspec-rails
   rswag
+  rswag-api
+  rswag-specs
+  rswag-ui
   rubocop-rails-omakase
   shoulda-matchers
   sidekiq

--- a/app/controllers/api/v1/products_controller.rb
+++ b/app/controllers/api/v1/products_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::ProductsController < ApplicationController
     before_action :authenticate_user!
+    before_action :set_product, only: [ :show ]
 
     def index
         authorize Product
@@ -8,6 +9,7 @@ class Api::V1::ProductsController < ApplicationController
         render json: @products.map { |product|
             base = {
                 id: product.id,
+                sku: product.sku,
                 name: product.name,
                 price: product.price,
                 is_bundle: product.is_bundle,
@@ -24,5 +26,23 @@ class Api::V1::ProductsController < ApplicationController
             end
             base
         }
+    end
+
+    def show
+        authorize Product
+        render json: {
+            id: @product.id,
+            sku: @product.sku,
+            name: @product.name,
+            description: @product.description,
+            price: @product.price
+        }, status: :ok
+    end
+
+    private
+    def set_product
+        @product = Product.find(params[:id])
+    rescue ActiveRecord::RecordNotFound
+        render json: { error: "Product not found" }, status: :not_found
     end
 end

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,0 +1,13 @@
+Rswag::Api.configure do |c|
+  # Specify a root folder where Swagger JSON files are located
+  # This is used by the Swagger middleware to serve requests for API descriptions
+  # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
+  # that it's configured to generate files in the same folder
+  c.openapi_root = Rails.root.to_s + "/swagger"
+
+  # Inject a lambda function to alter the returned Swagger prior to serialization
+  # The function will have access to the rack env for the current request
+  # For example, you could leverage this to dynamically assign the "host" property
+  #
+  # c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+end

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -1,0 +1,15 @@
+Rswag::Ui.configure do |c|
+  # List the Swagger endpoints that you want to be documented through the
+  # swagger-ui. The first parameter is the path (absolute or relative to the UI
+  # host) to the corresponding endpoint and the second is a title that will be
+  # displayed in the document selector.
+  # NOTE: If you're using rspec-api to expose Swagger files
+  # (under openapi_root) as JSON or YAML endpoints, then the list below should
+  # correspond to the relative paths for those endpoints.
+
+  c.swagger_endpoint "/api-docs/v1/swagger.yaml", "API V1 Docs"
+
+  # Add Basic Auth in case your API is private
+  # c.basic_auth_enabled = true
+  # c.basic_auth_credentials 'username', 'password'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  mount Rswag::Ui::Engine => "/api-docs"
+  mount Rswag::Api::Engine => "/api-docs"
+
   devise_for :users, path: "api/v1/", path_names: {
     sign_in: "login",
     sign_out: "logout",
@@ -10,7 +13,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :products, only: [ :index ]
+      resources :products, only: [ :index, :show ]
     end
   end
 end

--- a/spec/integration/api/v1/product_spec.rb
+++ b/spec/integration/api/v1/product_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'swagger_helper'
+
+RSpec.describe 'API::V1::Products', type: :request do
+  let(:admin) { User.create!(name: "Admin", email: "admin@example.com", password: "password", role: :admin) }
+  let(:auth_token) { auth_headers(admin)["Authorization"] } # use your auth_helper
+  let(:warehouse) { Warehouse.create!(name: "Main Warehouse", address: "123 Street") }
+  let(:inventory_location) { InventoryLocation.create!(storage_id: "BIN-03", warehouse: warehouse, capacity: 100, unique_item_limits: 5) }
+  path '/api/v1/products' do
+    get('List all products') do
+      tags 'Products'
+      produces 'application/json'
+      security [ bearerAuth: [] ]
+
+      response(200, 'successful') do
+        let(:Authorization) { auth_token }
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v1/products/{id}' do
+    get('Show a product') do
+      tags 'Products'
+      produces 'application/json'
+      security [ bearerAuth: [] ]
+      parameter name: :id, in: :path, type: :string, description: 'Product ID'
+
+      response(200, 'successful') do
+        let(:Authorization) { auth_token }
+        let(:id) { Product.create!(name: 'Coffee', price: 10, created_by_user: admin, inventory_location: inventory_location).id }
+        run_test!
+      end
+
+      response(404, 'not found') do
+        let(:Authorization) { auth_token }
+        let(:id) { '999' }
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/integration/api/v1/registrations_spec.rb
+++ b/spec/integration/api/v1/registrations_spec.rb
@@ -1,0 +1,40 @@
+# spec/integration/api/v1/auth/registrations_spec.rb
+require 'swagger_helper'
+
+RSpec.describe 'API V1 - User Registration', type: :request do
+  path '/api/v1/signup' do
+    post 'Registers a new user' do
+      tags 'Authentication'
+      consumes 'application/json'
+      produces 'application/json'
+
+      parameter name: :user, in: :body, schema: {
+        type: :object,
+        properties: {
+            user: {
+            type: :object,
+            properties: {
+                name: { type: :string },
+                email: { type: :string },
+                password: { type: :string },
+                password_confirmation: { type: :string }
+            },
+            required: %w[name email password password_confirmation]
+            }
+        },
+        required: [ 'user' ]
+      }
+
+      response '201', 'User registered successfully' do
+        let(:user) { { user: { name: 'John Doe', email: 'john@example.com', password: 'password', password_confirmation: 'password' } } }
+
+        run_test!
+      end
+
+      response '400', 'Validation error' do
+        let(:user) { { email: 'invalid@example.com' } }
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/integration/api/v1/sessions_spec.rb
+++ b/spec/integration/api/v1/sessions_spec.rb
@@ -1,0 +1,58 @@
+# spec/integration/api/v1/auth/sessions_spec.rb
+require 'swagger_helper'
+
+RSpec.describe 'API V1 - User Login', type: :request do
+  path '/api/v1/login' do
+    post 'Logs in an existing user' do
+      tags 'Authentication'
+      consumes 'application/json'
+      produces 'application/json'
+
+      parameter name: :credentials, in: :body, schema: {
+        type: :object,
+        properties: {
+            user: {
+            type: :object,
+            properties: {
+                email: { type: :string },
+                password: { type: :string }
+            },
+            required: %w[email password]
+            }
+        },
+        required: %w[email password]
+      }
+
+      response '200', 'User logged in successfully' do
+        let(:user) { User.create!(name: 'John', email: 'john@example.com', password: 'password') }
+        let(:credentials) do
+        {
+            user: {
+            email: user[:email],
+            password: 'password'
+            }
+        }
+        end
+
+        # Ensure params are sent as JSON
+        run_test! do |response|
+          expect(response).to have_http_status(:ok)
+          json = JSON.parse(response.body)
+          token = response.headers['Authorization'].split(' ').last
+          expect(json['data']['email']).to eq(user.email)
+          expect(token).to be_present
+        end
+      end
+
+      response '401', 'Invalid credentials' do
+        let(:credentials) { { email: 'john@example.com', password: 'wrong' } }
+
+        run_test! do |response|
+          expect(response).to have_http_status(:unauthorized)
+          json = JSON.parse(response.body)
+          expect(json['error']).to eq('You need to sign in or sign up before continuing.')
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/products_spec.rb
+++ b/spec/requests/api/v1/products_spec.rb
@@ -56,4 +56,30 @@ RSpec.describe "Api::V1::Products", type: :request do
       end
     end
   end
+
+  describe "GET /show" do
+    context "when user is authenticated" do
+      it "returns the product details" do
+        get "/api/v1/products/#{coffee.id}", headers: auth_headers(admin)
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json["name"]).to eq("Coffee")
+        expect(json["price"]).to eq("10.0")
+      end
+
+      it "returns 404 for non-existent product" do
+        get "/api/v1/products/9999", headers: auth_headers(admin)
+        expect(response).to have_http_status(:not_found)
+        json = JSON.parse(response.body)
+        expect(json["error"]).to eq("Product not found")
+      end
+    end
+
+    context "when user is unauthenticated" do
+      it "returns 401 unauthorized" do
+        get "/api/v1/products/#{coffee.id}"
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
 end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.configure do |config|
+  # Specify a root folder where Swagger JSON files are generated
+  # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
+  # to ensure that it's configured to serve Swagger from the same folder
+  config.openapi_root = Rails.root.join('swagger').to_s
+
+  # Define one or more Swagger documents and provide global metadata for each one
+  # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
+  # be generated at the provided relative path under openapi_root
+  # By default, the operations defined in spec files are added to the first
+  # document below. You can override this behavior by adding a openapi_spec tag to the
+  # the root example_group in your specs, e.g. describe '...', openapi_spec: 'v2/swagger.json'
+  config.openapi_specs = {
+    'v1/swagger.yaml' => {
+      openapi: '3.0.1',
+      info: {
+        title: 'API V1',
+        version: 'v1'
+      },
+      paths: {},
+      components: {
+        securitySchemes: {
+          bearerAuth: {
+            type: :http,
+            scheme: :bearer,
+            bearerFormat: :JWT
+          }
+        }
+      },
+      servers: [
+        {
+          url: 'http://localhost:4000',
+          description: 'Local server'
+        }
+      ]
+    }
+
+
+  }
+
+  # Specify the format of the output Swagger file when running 'rswag:specs:swaggerize'.
+  # The openapi_specs configuration option has the filename including format in
+  # the key, this may want to be changed to avoid putting yaml in json files.
+  # Defaults to json. Accepts ':json' and ':yaml'.
+  config.openapi_format = :yaml
+end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -1,0 +1,109 @@
+---
+openapi: 3.0.1
+info:
+  title: API V1
+  version: v1
+paths:
+  "/api/v1/products":
+    get:
+      summary: List all products
+      tags:
+      - Products
+      security:
+      - bearerAuth: []
+      responses:
+        '200':
+          description: successful
+  "/api/v1/products/{id}":
+    get:
+      summary: Show a product
+      tags:
+      - Products
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: id
+        in: path
+        description: Product ID
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: successful
+        '404':
+          description: not found
+  "/api/v1/signup":
+    post:
+      summary: Registers a new user
+      tags:
+      - Authentication
+      parameters: []
+      responses:
+        '200':
+          description: User registered successfully
+        '400':
+          description: Validation error
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                user:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    email:
+                      type: string
+                    password:
+                      type: string
+                    password_confirmation:
+                      type: string
+                  required:
+                  - name
+                  - email
+                  - password
+                  - password_confirmation
+              required:
+              - user
+  "/api/v1/login":
+    post:
+      summary: Logs in an existing user
+      tags:
+      - Authentication
+      parameters: []
+      responses:
+        '200':
+          description: User logged in successfully
+        '401':
+          description: Invalid credentials
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                user:
+                  type: object
+                  properties:
+                    email:
+                      type: string
+                    password:
+                      type: string
+                  required:
+                  - email
+                  - password
+              required:
+              - email
+              - password
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+servers:
+- url: http://localhost:4000
+  description: Local server


### PR DESCRIPTION
# Feature - Product show Endpoint
### Summary
This PR introduces the `show` endpoint for products and integrates Swagger documentation for API clients.

#### Features Implemented
- **GET /api/v1/products/:id**
  - Returns detailed information for a single product:
    - `id`, `sku`, `name`, `description`, `price`
  - Returns `404 Not Found` for non-existent products
  - Secured using Pundit (`authorize Product`)
- **Swagger Documentation**
  - Documented the `show` endpoint in `spec/integration/api/v1/products_spec.rb`
  - Provides request and response schemas
  - Supports API exploration via Rswag UI

#### Tests
- RSpec tests for:
  - Successfully fetching a product
  - Handling non-existent product with 404
