### PR TITLE
Fix - Remove inventory_location association from Product

### DIFF
--- a/app/controllers/api/v1/products_controller.rb
+++ b/app/controllers/api/v1/products_controller.rb
@@ -12,8 +12,7 @@ class Api::V1::ProductsController < ApplicationController
                 sku: product.sku,
                 name: product.name,
                 price: product.price,
-                is_bundle: product.is_bundle,
-                inventory_location_id: product.inventory_location_id
+                is_bundle: product.is_bundle
             }
             if product.is_bundle?
                 base[:components] = product.components.map do |component|
@@ -54,7 +53,7 @@ class Api::V1::ProductsController < ApplicationController
     private
 
     def product_params
-        params.require(:product).permit(:name, :price, :inventory_location_id)
+        params.require(:product).permit(:name, :price)
     end
 
     def set_product

--- a/app/models/inventory_location.rb
+++ b/app/models/inventory_location.rb
@@ -1,6 +1,7 @@
 class InventoryLocation < ApplicationRecord
   belongs_to :warehouse
-  has_many :products, dependent: :nullify
+  has_many :inventory_summaries, dependent: :destroy
+  has_many :products, through: :inventory_summaries
 
   validates :storage_id, presence: true
   validates :unique_item_limits, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true

--- a/app/models/inventory_summary.rb
+++ b/app/models/inventory_summary.rb
@@ -8,6 +8,8 @@ class InventorySummary < ApplicationRecord
   validates :quantity_on_hand, presence: true, numericality: { greater_than_or_equal_to: 0 }
   validates :reserved_quantity, numericality: { greater_than_or_equal_to: 0 }
   validate :reserved_cannot_exceed_on_hand
+  validates :inventory_status, presence: true
+
 
   private
   def reserved_cannot_exceed_on_hand

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -3,7 +3,6 @@ class Product < ApplicationRecord
   belongs_to :created_by_user, class_name: "User"
 
   validates :sku, presence: true, uniqueness: true
-  validate :respect_location_unique_item_limits
   validates :name, presence: true
   validates :price, numericality: { greater_than_or_equal_to: 0 }, unless: :is_bundle?
 
@@ -12,7 +11,8 @@ class Product < ApplicationRecord
 
   has_many :inverse_bundled_products, class_name: "BundledProduct", foreign_key: :component_id, dependent: :destroy
   has_many :bundles, through: :inverse_bundled_products, source: :bundle
-  belongs_to :inventory_location,
+  has_many :inventory_summaries, dependent: :destroy
+  has_many :inventory_locations, through: :inventory_summaries
 
 
   private
@@ -32,18 +32,5 @@ class Product < ApplicationRecord
     end
 
     self.sku = base_sku
-  end
-
-  def respect_location_unique_item_limits
-    return if inventory_location.nil?
-    return if inventory_location.unique_item_limits.nil?
-
-    current_unique_count = inventory_location.products.distinct.count
-    # If this is a new record, it hasn’t been counted yet → add 1
-    current_unique_count += 1 if new_record?
-
-    if current_unique_count > inventory_location.unique_item_limits
-      errors.add(:inventory_location, "has reached its unique product limit of #{inventory_location.unique_item_limits}")
-    end
   end
 end

--- a/db/migrate/20251011145958_remove_inventory_location_id_from_products.rb
+++ b/db/migrate/20251011145958_remove_inventory_location_id_from_products.rb
@@ -1,0 +1,16 @@
+class RemoveInventoryLocationIdFromProducts < ActiveRecord::Migration[7.2]
+  def up
+    # 1️⃣ Optional: backup existing data (if you might need it)
+    # execute "CREATE TABLE products_backup AS SELECT * FROM products"
+
+    # 2️⃣ Remove foreign key & column safely
+    remove_foreign_key :products, :inventory_locations if foreign_key_exists?(:products, :inventory_locations)
+    remove_column :products, :inventory_location_id, :bigint
+  end
+
+  def down
+    # rollback support
+    add_column :products, :inventory_location_id, :bigint
+    add_foreign_key :products, :inventory_locations
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_10_06_132727) do
+ActiveRecord::Schema[7.2].define(version: 2025_10_11_145958) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -76,9 +76,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_06_132727) do
     t.bigint "created_by_user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "inventory_location_id", null: false
     t.index ["created_by_user_id"], name: "index_products_on_created_by_user_id"
-    t.index ["inventory_location_id"], name: "index_products_on_inventory_location_id"
     t.index ["sku"], name: "index_products_on_sku", unique: true
   end
 
@@ -115,6 +113,5 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_06_132727) do
   add_foreign_key "inventory_summaries", "inventory_locations"
   add_foreign_key "inventory_summaries", "inventory_statuses"
   add_foreign_key "inventory_summaries", "products"
-  add_foreign_key "products", "inventory_locations"
   add_foreign_key "products", "users", column: "created_by_user_id"
 end

--- a/spec/integration/api/v1/product_spec.rb
+++ b/spec/integration/api/v1/product_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'API::V1::Products', type: :request do
 
       response(200, 'successful') do
         let(:Authorization) { auth_token }
-        let(:id) { Product.create!(name: 'Coffee', price: 10, created_by_user: admin, inventory_location: inventory_location).id }
+        let(:id) { Product.create!(name: 'Coffee', price: 10, created_by_user: admin).id }
         run_test!
       end
 
@@ -56,8 +56,7 @@ RSpec.describe 'API::V1::Products', type: :request do
             type: :object,
             properties: {
               name: { type: :string },
-              price: { type: :number },
-              inventory_location_id: { type: :integer }
+              price: { type: :number }
             },
             required: %w[name price inventory_location_id]
           }
@@ -71,8 +70,7 @@ RSpec.describe 'API::V1::Products', type: :request do
           {
             product: {
               name: 'Coca Cola',
-              price: 15,
-              inventory_location_id: inventory_location.id
+              price: 15
             }
           }
         end

--- a/spec/models/bundled_product_spec.rb
+++ b/spec/models/bundled_product_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe BundledProduct, type: :model do
     let(:warehouse) { Warehouse.create!(name: "Main Warehouse", address: "1234 Main St") }
     let(:location) { InventoryLocation.create!(storage_id: "LOC-001", capacity: 100, warehouse: warehouse) }
     let(:user) { User.create!(name: "Test User", email: "test@example.com", password: "password") }
-    let(:bundle) { Product.create!(name: "Bundle Product", is_bundle: true, price: 10, created_by_user: user, inventory_location: location) }
-    let(:component) { Product.create!(name: "Component Product", is_bundle: false, price: 5, created_by_user: user, inventory_location: location) }
+    let(:bundle) { Product.create!(name: "Bundle Product", is_bundle: true, price: 10, created_by_user: user) }
+    let(:component) { Product.create!(name: "Component Product", is_bundle: false, price: 5, created_by_user: user) }
 
     it "is valid with bundle and component" do
       bundled_product = BundledProduct.new(bundle: bundle, component: component, quantity: 2)
@@ -24,13 +24,13 @@ RSpec.describe BundledProduct, type: :model do
     end
 
     it "is invalid if bundle is not a bundle product" do
-      not_a_bundle = Product.create!(name: "Not a Bundle", is_bundle: false, price: 5, created_by_user: user, inventory_location: location)
+      not_a_bundle = Product.create!(name: "Not a Bundle", is_bundle: false, price: 5, created_by_user: user)
       bundled_product = BundledProduct.new(bundle: not_a_bundle, component: component, quantity: 2)
       expect(bundled_product).not_to be_valid
     end
 
     it "is invalid if component is a bundle product" do
-      component = Product.create!(name: "Component Bundle", is_bundle: true, price: 15, created_by_user: user, inventory_location: location)
+      component = Product.create!(name: "Component Bundle", is_bundle: true, price: 15, created_by_user: user)
       bundled_product = BundledProduct.new(bundle: bundle, component: component, quantity: 2)
       expect(bundled_product).not_to be_valid
     end

--- a/spec/models/inventory_location_spec.rb
+++ b/spec/models/inventory_location_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe InventoryLocation, type: :model do
 
   describe "associations" do
     it { should belong_to(:warehouse) }
-    it { should have_many(:products).dependent(:nullify) }
+    it { should have_many(:inventory_summaries).dependent(:destroy) }
+    it { should have_many(:products).through(:inventory_summaries) }
   end
 
   describe "validations" do
@@ -57,21 +58,6 @@ RSpec.describe InventoryLocation, type: :model do
     it "is valid if unique_item_limits is nil (optional)" do
       subject.unique_item_limits = nil
       expect(subject).to be_valid
-    end
-
-    it "does not allow more unique products than unique_item_limits" do
-      # Add 2 unique products → OK
-      p1 = Product.create!(name: "Laptop", price: 10, created_by_user: user, inventory_location: subject)
-      p2 = Product.create!(name: "Tea", price: 20, created_by_user: user, inventory_location: subject)
-      p3 = Product.create!(name: "Watch", price: 10, created_by_user: user, inventory_location: subject)
-      p4 = Product.create!(name: "Bag", price: 20, created_by_user: user, inventory_location: subject)
-      p5 = Product.create!(name: "Hoodie", price: 10, created_by_user: user, inventory_location: subject)
-      expect(subject.reload).to be_valid
-
-      # Try to add a 3rd unique product → should fail
-      p6 = Product.new(name: "Shoes", price: 30, created_by_user: user, inventory_location: subject)
-      expect(p6.save).to be false
-      expect(p6.errors[:inventory_location]).to include("has reached its unique product limit of 5")
     end
   end
 end

--- a/spec/models/inventory_movement_spec.rb
+++ b/spec/models/inventory_movement_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe InventoryMovement, type: :model do
     let(:location1) { InventoryLocation.create!(storage_id: "BIN-01", warehouse: warehouse, capacity: 300) }
     let(:location2) { InventoryLocation.create!(storage_id: "BIN-02", warehouse: warehouse, capacity: 300) }
     let(:user) { User.create!(name: "User1", email: "a@b.com", password: "123456") }
-    let(:product) { Product.create!(name: "Coffee", price: 10, created_by_user: user, inventory_location: location1) }
+    let(:product) { Product.create!(name: "Coffee", price: 10, created_by_user: user) }
     let(:status) { InventoryStatus.create!(name: "Sellable") }
     let(:summary) { InventorySummary.create!(product: product, inventory_location: location1, inventory_status: status, quantity_on_hand: 10, reserved_quantity: 0) }
 

--- a/spec/models/inventory_status_spec.rb
+++ b/spec/models/inventory_status_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe InventorySummary, type: :model do
   let(:user) { User.create!(name: "Tester", email: "test@example.com", password: "password") }
   let(:warehouse) { Warehouse.create!(name: "Main", address: "123 St") }
   let(:location) { InventoryLocation.create!(storage_id: "BIN-01", warehouse: warehouse) }
-  let(:product) { Product.create!(name: "Coffee", price: 10, created_by_user: user, inventory_location: location) }
+  let(:product) { Product.create!(name: "Coffee", price: 10, created_by_user: user) }
   let(:status) { InventoryStatus.create!(name: "Sellable") }
 
   subject do

--- a/spec/models/inventory_summary_spec.rb
+++ b/spec/models/inventory_summary_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe InventorySummary, type: :model do
   let(:warehouse) { Warehouse.create!(name: "Main Warehouse", address: "123 Warehouse St") }
   let(:user) { User.create!(name: "Tester", email: "tester@example.com", password: "password") }
   let(:inventory_location) { InventoryLocation.create!(storage_id: "AEC-01", warehouse: warehouse, capacity: 500, unique_item_limits: 12) }
-  let(:product) { Product.create!(name: "Test Product", price: 20.0, created_by_user: user, inventory_location: inventory_location) }
+  let(:product) { Product.create!(name: "Test Product", price: 20.0, created_by_user: user) }
   let(:status) { InventoryStatus.create!(name: "Sellable") }
 
   subject do

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -11,8 +11,7 @@ RSpec.describe Product, type: :model do
       price: 100.50,
       is_bundle: false,
       metadata: { color: "red" },
-      created_by_user: user,
-      inventory_location: location
+      created_by_user: user
     )
   end
 
@@ -56,8 +55,7 @@ RSpec.describe Product, type: :model do
         name: "Coffee",
         price: 10,
         is_bundle: false,
-        created_by_user: user,
-        inventory_location: location
+        created_by_user: user
       )
       expect(product.sku.length).to eq(8)
       expect(product.sku).to match(/[A-Z0-9]{8}/)
@@ -69,8 +67,7 @@ RSpec.describe Product, type: :model do
         name: "Coffee",
         price: 10,
         is_bundle: false,
-        created_by_user: user,
-        inventory_location: location
+        created_by_user: user
       )
 
       # Second product with same name should fail
@@ -78,8 +75,7 @@ RSpec.describe Product, type: :model do
         name: "Coffee",
         price: 15,
         is_bundle: false,
-        created_by_user: user,
-        inventory_location: location
+        created_by_user: user
       )
 
       expect(second).not_to be_valid

--- a/spec/requests/api/v1/products_spec.rb
+++ b/spec/requests/api/v1/products_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe "Api::V1::Products", type: :request do
   let(:warehouse) { Warehouse.create!(name: "Main Warehouse", address: "123 Street") }
   let(:bin1) { InventoryLocation.create!(storage_id: "BIN-01", warehouse: warehouse, capacity: 100, unique_item_limits: 5) }
 
-  let!(:coffee) { Product.create!(name: "Coffee", price: 10, created_by_user: admin, inventory_location: bin1) }
-  let!(:tea) { Product.create!(name: "Tea", price: 8, created_by_user: admin, inventory_location: bin1) }
+  let!(:coffee) { Product.create!(name: "Coffee", price: 10, created_by_user: admin) }
+  let!(:tea) { Product.create!(name: "Tea", price: 8, created_by_user: admin) }
 
   # Bundle example
-  let!(:coffee_tea_bundle) { Product.create!(name: "Coffee & Tea Bundle", price: 17, is_bundle: true, created_by_user: admin, inventory_location: bin1) }
+  let!(:coffee_tea_bundle) { Product.create!(name: "Coffee & Tea Bundle", price: 17, is_bundle: true, created_by_user: admin) }
   let!(:bundle_relation) { BundledProduct.create!(bundle: coffee_tea_bundle, component: coffee, quantity: 1) }
   let!(:bundle_relation2) { BundledProduct.create!(bundle: coffee_tea_bundle, component: tea, quantity: 1) }
 
@@ -89,8 +89,7 @@ RSpec.describe "Api::V1::Products", type: :request do
         {
           product: {
             name: "Diet Coke",
-            price: 10,
-            inventory_location_id: bin1.id
+            price: 10
           }
         }.to_json
       end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -39,8 +39,6 @@ paths:
                       type: string
                     price:
                       type: number
-                    inventory_location_id:
-                      type: integer
                   required:
                   - name
                   - price


### PR DESCRIPTION
# 🚀 Remove InventoryLocation from Product

## **Summary**
This PR removes the `inventory_location` association from the `Product` model.  
Products now represent catalog items only and no longer track inventory locations directly. Inventory quantities are tracked via `InventorySummary`.

---

## **Key Changes**
* ✂️ Removed `inventory_location_id` column from `products` table
* 🔄 Updated `Product` model: removed `belongs_to :inventory_location` and related validations
* 🧪 Updated RSpec model and request specs to remove inventory_location dependencies
* 📘 Updated API controllers and Swagger docs to remove inventory_location from product creation payload
* 🗂 Inventory quantities now fully handled through `InventorySummary`

---

## **Impact**
* Product creation no longer requires an inventory location
* API responses for products no longer include inventory_location
* Inventory tracking is handled solely through `InventorySummary`

---

## **Example Request (POST /api/v1/products)**
```json
{
  "product": {
    "name": "Diet Coke",
    "price": 10
  }
}
```
### **Successful Response (201 created)**
```json
{
  "product": {
    "id": 17,
    "sku": "AACCKLOO",
    "name": "Diet Coke",
    "description": null,
    "price": "10.0",
    "is_bundle": false,
    "metadata": {},
    "created_by_user_id": 2,
    "created_at": "2025-10-10T14:30:36.137Z",
    "updated_at": "2025-10-10T14:30:36.137Z",
  }
}
```
### **Validation Error Response (422 Unprocessable Entity)**
```json
{
  "errors": [
    "Name can't be blank",
    "Price can't be blank"
  ]
}
```
### **Test Coverage**
 ✅ RSpec request and model tests updated
 ✅ Swagger/OpenAPI documentation updated