### PR TITLE
🚀 Add InventoryLocations API endpoints

### DIFF
--- a/app/controllers/api/v1/inventory_locations_controller.rb
+++ b/app/controllers/api/v1/inventory_locations_controller.rb
@@ -1,0 +1,40 @@
+class Api::V1::InventoryLocationsController < ApplicationController
+    before_action :authenticate_user!
+
+    def inventory_locations_by_warehouse
+        authorize InventoryLocation
+        warehouse_id = params[:warehouse_id]
+        if warehouse_id.present?
+            @locations = InventoryLocation.where(warehouse_id: warehouse_id)
+            render json: @locations.select(:id, :storage_id), status: :ok
+        else
+            render json: { error: "warehouse_id parameter is required" }, status: :bad_request
+        end
+    rescue ActiveRecord::RecordNotFound
+        render json: { error: "Warehouse not found" }, status: :not_found
+    end
+
+    def show
+        @location = InventoryLocation.find(params[:id])
+        sql = <<-SQL
+        SELECT#{' '}
+            p.name,#{' '}
+            p.sku,#{' '}
+            s.quantity_on_hand,#{' '}
+            s.reserved_quantity,
+            st.name AS status
+        FROM inventory_summaries s
+        JOIN products p ON s.product_id = p.id
+        JOIN inventory_statuses st ON s.inventory_status_id = st.id
+        WHERE s.inventory_location_id = ?
+        SQL
+        @inventory_details = ActiveRecord::Base.connection.exec_query(
+            ActiveRecord::Base.send(:sanitize_sql_array, [ sql, @location.id ])
+        )
+
+        authorize @location
+        render json: { location: @location, inventory_details: @inventory_details }, status: :ok
+    rescue ActiveRecord::RecordNotFound
+        render json: { error: "Inventory Location not found" }, status: :not_found
+    end
+end

--- a/app/policies/inventory_location_policy.rb
+++ b/app/policies/inventory_location_policy.rb
@@ -1,0 +1,16 @@
+class InventoryLocationPolicy < ApplicationPolicy
+  def inventory_locations_by_warehouse?
+    user.present?
+  end
+
+  def show?
+    user.present?
+  end
+
+  class Scope < ApplicationPolicy::Scope
+    # NOTE: Be explicit about which records you allow access to!
+    def resolve
+      scope.all
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,11 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :products, only: [ :index, :show, :create ]
+      resources :inventory_locations, only: [ :show ] do
+        collection do
+          get "by_warehouse", to: "inventory_locations#inventory_locations_by_warehouse"
+        end
+      end
     end
   end
 end

--- a/spec/integration/api/v1/inventory_location_spec.rb
+++ b/spec/integration/api/v1/inventory_location_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'swagger_helper'
+
+RSpec.describe 'API::V1::InventoryLocations', type: :request do
+  let(:user) { User.create!(name: "Manager", email: "manager@example.com", password: "password", role: :staff) }
+  let(:auth_token) { auth_headers(user)["Authorization"] }
+
+  let(:warehouse) { Warehouse.create!(name: "Main Warehouse", address: "123 Street") }
+  let!(:location1) { InventoryLocation.create!(storage_id: "BIN-01", warehouse: warehouse, capacity: 500) }
+  let!(:location2) { InventoryLocation.create!(storage_id: "BIN-02", warehouse: warehouse, capacity: 300) }
+
+  let(:product) { Product.create!(name: "Test Product", price: 20.0, created_by_user: user) }
+  let(:status) { InventoryStatus.create!(name: "Sellable") }
+  let!(:inventory_summary) do
+    InventorySummary.create!(
+      product: product,
+      inventory_location: location1,
+      inventory_status: status,
+      quantity_on_hand: 10,
+      reserved_quantity: 2
+    )
+  end
+
+  path '/api/v1/inventory_locations/by_warehouse' do
+    get('Get inventory locations by warehouse') do
+      tags 'InventoryLocations'
+      produces 'application/json'
+      security [ bearerAuth: [] ]
+      parameter name: :warehouse_id, in: :query, type: :integer, description: 'Warehouse ID'
+
+      response(200, 'successful') do
+        let(:Authorization) { auth_token }
+        let(:warehouse_id) { warehouse.id }
+
+        run_test! do |response|
+          expect(response).to have_http_status(:ok)
+          json = JSON.parse(response.body)
+          expect(json.length).to eq(2)
+          expect(json.first).to have_key('id')
+          expect(json.first).to have_key('storage_id')
+        end
+      end
+
+      response(400, 'bad request') do
+        let(:Authorization) { auth_token }
+        let(:warehouse_id) { nil }
+        run_test! do |response|
+          expect(response).to have_http_status(:bad_request)
+          json = JSON.parse(response.body)
+          expect(json["error"]).to eq("warehouse_id parameter is required")
+        end
+      end
+    end
+  end
+
+  path '/api/v1/inventory_locations/{id}' do
+    get('Show inventory details for a location') do
+      tags 'InventoryLocations'
+      produces 'application/json'
+      security [ bearerAuth: [] ]
+      parameter name: :id, in: :path, type: :integer, description: 'Inventory Location ID'
+
+      response(200, 'successful') do
+        let(:Authorization) { auth_token }
+        let(:id) { location1.id }
+
+        run_test! do |response|
+          expect(response).to have_http_status(:ok)
+          json = JSON.parse(response.body)
+          expect(json["location"]["id"]).to eq(location1.id)
+          expect(json["inventory_details"].first["name"]).to eq(product.name)
+          expect(json["inventory_details"].first["quantity_on_hand"]).to eq(inventory_summary.quantity_on_hand)
+        end
+      end
+
+      response(404, 'not found') do
+        let(:Authorization) { auth_token }
+        let(:id) { 999 }
+        run_test! do |response|
+          expect(response).to have_http_status(:not_found)
+          json = JSON.parse(response.body)
+          expect(json["error"]).to eq("Inventory Location not found")
+        end
+      end
+    end
+  end
+end

--- a/spec/policies/inventory_location_policy_spec.rb
+++ b/spec/policies/inventory_location_policy_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe InventoryLocationPolicy, type: :policy do
+  let(:user) { User.new }
+
+  subject { described_class }
+end

--- a/spec/requests/api/v1/inventory_locations_spec.rb
+++ b/spec/requests/api/v1/inventory_locations_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe "API::V1::InventoryLocations", type: :request do
+  let(:user) { User.create!(name: "Tester", email: "tester@example.com", password: "password", role: "staff") }
+  let(:warehouse) { Warehouse.create!(name: "Main Warehouse", address: "Pune") }
+  let!(:location1) { InventoryLocation.create!(storage_id: "BIN-01", warehouse: warehouse, capacity: 300) }
+  let!(:location2) { InventoryLocation.create!(storage_id: "BIN-02", warehouse: warehouse, capacity: 500) }
+
+  let(:status) { InventoryStatus.create!(name: "Sellable") }
+  let(:product) { Product.create!(name: "Laptop", price: 1000, created_by_user: user) }
+  let!(:summary) do
+    InventorySummary.create!(
+      product: product,
+      inventory_location: location1,
+      inventory_status: status,
+      quantity_on_hand: 10,
+      reserved_quantity: 2
+    )
+  end
+
+
+  describe "GET /api/v1/inventory_locations/by_warehouse" do
+    context "when warehouse_id is provided" do
+      it "returns the locations for that warehouse" do
+        get "/api/v1/inventory_locations/by_warehouse", headers:  auth_headers(user), params: { warehouse_id: warehouse.id }
+
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json).to be_an(Array)
+        expect(json.size).to eq(2)
+        expect(json.first.keys).to include("id", "storage_id")
+      end
+    end
+
+    context "when warehouse_id is missing" do
+      it "returns a bad request error" do
+        get "/api/v1/inventory_locations/by_warehouse", headers: auth_headers(user)
+
+        expect(response).to have_http_status(:bad_request)
+        json = JSON.parse(response.body)
+        expect(json["error"]).to eq("warehouse_id parameter is required")
+      end
+    end
+  end
+
+  describe "GET /api/v1/inventory_locations/:id" do
+    context "when location exists" do
+      it "returns inventory details for that location" do
+        get "/api/v1/inventory_locations/#{location1.id}", headers: auth_headers(user)
+
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        puts "Response body: #{response.body}"
+        expect(json["location"]["storage_id"]).to eq("BIN-01")
+        expect(json["inventory_details"]).to be_an(Array)
+        expect(json["inventory_details"].first["name"]).to eq("Laptop")
+      end
+    end
+
+    context "when location does not exist" do
+      it "returns not found" do
+        get "/api/v1/inventory_locations/999999", headers: auth_headers(user)
+
+        expect(response).to have_http_status(:not_found)
+        json = JSON.parse(response.body)
+        expect(json["error"]).to eq("Inventory Location not found")
+      end
+    end
+  end
+end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -4,6 +4,43 @@ info:
   title: API V1
   version: v1
 paths:
+  "/api/v1/inventory_locations/by_warehouse":
+    get:
+      summary: Get inventory locations by warehouse
+      tags:
+      - InventoryLocations
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: warehouse_id
+        in: query
+        description: Warehouse ID
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: successful
+        '400':
+          description: bad request
+  "/api/v1/inventory_locations/{id}":
+    get:
+      summary: Show inventory details for a location
+      tags:
+      - InventoryLocations
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: id
+        in: path
+        description: Inventory Location ID
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: successful
+        '404':
+          description: not found
   "/api/v1/products":
     get:
       summary: List all products


### PR DESCRIPTION
# 🚀 Add InventoryLocations API Endpoints

## **Summary**
This PR implements endpoints for managing and viewing inventory locations:

#### **`GET /api/v1/inventory_locations/by_warehouse?warehouse_id=?`**
Returns all inventory locations for the specified warehouse. Requires `warehouse_id` query parameter.

#### **`GET /api/v1/inventory_locations/:id`**
Returns detailed inventory information for a specific location, including:

- Product name & SKU
- Quantity on hand
- Reserved quantity
- Inventory status

#### Authorization is enforced using **Pundit**.
---

## **Features**
- ✅ List inventory locations by warehouse
- ✅ Show inventory summaries for a specific location
- ✅ SQL query optimized for fetching products and quantities
- ✅ Error handling for:
  - Missing `warehouse_id`
  - Inventory location not found
- 🔐 Pundit policies added to restrict access
