### PR TITLE
feat(audit-logs): implement centralized audit logging for all models

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,11 @@
 class ApplicationController < ActionController::API
     include Pundit
     rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+    before_action :set_current_user
+
+    def set_current_user
+        Current.user = current_user if defined?(current_user)
+    end
 
     private
 

--- a/app/models/audit_log.rb
+++ b/app/models/audit_log.rb
@@ -1,0 +1,4 @@
+class AuditLog < ApplicationRecord
+  belongs_to :user
+  validates :action_type, :object_type, :object_id, presence: true
+end

--- a/app/models/concerns/auditable.rb
+++ b/app/models/concerns/auditable.rb
@@ -1,0 +1,23 @@
+module Auditable
+  extend ActiveSupport::Concern
+
+  included do
+    after_create  -> { log_audit("CREATE") }
+    after_update  -> { log_audit("UPDATE") }
+    after_destroy -> { log_audit("DELETE") }
+  end
+
+  private
+
+  def log_audit(action)
+    return unless Current.user.present?  # requires a thread-safe current user
+
+    AuditLog.create!(
+      user: Current.user,
+      action_type: action,
+      object_type: self.class.name,
+      object_id: id,
+      change_log: saved_changes
+    )
+  end
+end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,3 @@
+class Current < ActiveSupport::CurrentAttributes
+  attribute :user
+end

--- a/app/models/inventory_location.rb
+++ b/app/models/inventory_location.rb
@@ -1,4 +1,5 @@
 class InventoryLocation < ApplicationRecord
+  include Auditable
   belongs_to :warehouse
   has_many :inventory_summaries, dependent: :destroy
   has_many :products, through: :inventory_summaries

--- a/app/models/inventory_movement.rb
+++ b/app/models/inventory_movement.rb
@@ -1,4 +1,5 @@
 class InventoryMovement < ApplicationRecord
+  include Auditable
   belongs_to :inventory_summary
   belongs_to :transfer_from, class_name: "InventoryLocation", optional: true
   belongs_to :transfer_to, class_name: "InventoryLocation", optional: true

--- a/app/models/inventory_summary.rb
+++ b/app/models/inventory_summary.rb
@@ -1,4 +1,5 @@
 class InventorySummary < ApplicationRecord
+  include Auditable
   belongs_to :product
   belongs_to :inventory_location
   belongs_to :inventory_status

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,4 +1,5 @@
 class Product < ApplicationRecord
+  include Auditable
   before_validation :generate_sku, on: :create
   belongs_to :created_by_user, class_name: "User"
 

--- a/app/models/warehouse.rb
+++ b/app/models/warehouse.rb
@@ -1,4 +1,5 @@
 class Warehouse < ApplicationRecord
+    include Auditable
     has_many :inventory_locations, dependent: :destroy
 
     validates :name, presence: true

--- a/db/migrate/20251017124532_create_audit_logs.rb
+++ b/db/migrate/20251017124532_create_audit_logs.rb
@@ -1,0 +1,13 @@
+class CreateAuditLogs < ActiveRecord::Migration[7.2]
+  def change
+    create_table :audit_logs do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :action_type
+      t.string :object_type
+      t.integer :object_id
+      t.jsonb :change_log
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_10_11_145958) do
+ActiveRecord::Schema[7.2].define(version: 2025_10_17_124532) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "audit_logs", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "action_type"
+    t.string "object_type"
+    t.integer "object_id"
+    t.jsonb "change_log"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_audit_logs_on_user_id"
+  end
 
   create_table "bundled_products", force: :cascade do |t|
     t.bigint "bundle_id", null: false
@@ -103,6 +114,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_11_145958) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "audit_logs", "users"
   add_foreign_key "bundled_products", "products", column: "bundle_id"
   add_foreign_key "bundled_products", "products", column: "component_id"
   add_foreign_key "inventory_locations", "warehouses"

--- a/spec/factories/audit_logs.rb
+++ b/spec/factories/audit_logs.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :audit_log do
+    user { nil }
+    action_type { "MyString" }
+    object_type { "MyString" }
+    object_id { 1 }
+    change_log { "" }
+  end
+end

--- a/spec/models/audit_log_spec.rb
+++ b/spec/models/audit_log_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe Product, type: :model do
+  let(:user) { create(:user) }
+
+  before { Current.user = user }
+  after  { Current.user = nil }
+
+  it "creates an audit log on create" do
+    product = Product.create!(name: "Sprite", price: 10, created_by_user: user)
+
+    log = AuditLog.last
+    expect(log.action_type).to eq("CREATE")
+    expect(log.object_type).to eq("Product")
+    expect(log.object_id).to eq(product.id)
+    expect(log.user).to eq(user)
+  end
+
+  it "creates an audit log on update" do
+    product = create(:product, created_by_user: user)
+    product.update!(price: 12)
+
+    log = AuditLog.last
+    expect(log.action_type).to eq("UPDATE")
+    expect(log.change_log.keys).to include("price")
+  end
+
+  it "creates an audit log on destroy" do
+    product = create(:product, created_by_user: user)
+    product.destroy!
+
+    log = AuditLog.last
+    expect(log.action_type).to eq("DELETE")
+    expect(log.object_id).to eq(product.id)
+  end
+end

--- a/spec/requests/api/v1/products_spec.rb
+++ b/spec/requests/api/v1/products_spec.rb
@@ -104,6 +104,17 @@ RSpec.describe "Api::V1::Products", type: :request do
         json = JSON.parse(response.body)
         expect(json["product"]["name"]).to eq("Diet Coke")
       end
+
+      it "logs a product creation action" do
+        expect {
+          post "/api/v1/products", params: valid_params, headers: auth_headers(admin)
+        }.to change { AuditLog.count }.by(1)
+
+        log = AuditLog.last
+        expect(log.action_type).to eq("CREATE")
+        expect(log.object_type).to eq("Product")
+        expect(log.user).to eq(admin)
+      end
     end
   end
 end


### PR DESCRIPTION
# 🚀 Feature 0.2 - Add Centralized Audit Logs for All Models

### Overview
- Introduce centralized audit logging for all key models.
- Tracks create, update, and delete actions with user, object, and changes.
- Improves traceability, debugging, and accountability.

### Key Changes
- Added AuditLog model: ```user_id, action_type, object_type, object_id, changes (jsonb)```
- Created reusable Auditable concern for automatic logging
- Integrated auditing into core models
- Logs use ```saved_changes``` and associate entries with Current.user
- Added tests to verify log creation and accuracy

### Notes
- Logging applies only to API-triggered actions (console excluded for now)
- Logs include timestamp, user, object type & ID, and changed fields
- Image field and other metadata logging deferred for future updates
