### PR TITLE
fix - Query for inventory to avoid fetching duplicate summary after m…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ group :development, :test do
   gem "debug", platforms: %i[mri windows], require: "debug/prelude"
 
   # Static security analysis
-  gem "brakeman", require: false
+  gem "brakeman", "~> 7.1.1", require: false
 
   # Code style checks
   gem "rubocop-rails-omakase", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,7 +108,7 @@ GEM
     bigdecimal (3.2.3)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
-    brakeman (7.1.0)
+    brakeman (7.1.1)
       racc
     builder (3.3.0)
     bullet (8.0.8)
@@ -421,7 +421,7 @@ DEPENDENCIES
   annotate
   aws-sdk-s3
   bootsnap
-  brakeman
+  brakeman (~> 7.1.1)
   bullet
   cancancan
   database_cleaner-active_record

--- a/app/controllers/api/v1/inventory_locations_controller.rb
+++ b/app/controllers/api/v1/inventory_locations_controller.rb
@@ -6,13 +6,21 @@ class Api::V1::InventoryLocationsController < ApplicationController
         warehouse_id = params[:warehouse_id]
         if warehouse_id.present?
             sql = <<-SQL
-                SELECT#{' '}
-                    l.id,#{' '}
-                    l.storage_id,#{' '}
-                    COUNT(p.id) AS product_count,#{' '}
+                SELECT
+                    l.id,
+                    l.storage_id,
+                    COUNT(p.id) AS product_count,
                     SUM(s.quantity_on_hand) AS total_quantity
                 FROM inventory_locations l
-                LEFT JOIN inventory_summaries s ON l.id = s.inventory_location_id
+                LEFT JOIN (
+                    SELECT *
+                    FROM inventory_summaries
+                    WHERE id IN (
+                        SELECT MAX(id)
+                        FROM inventory_summaries
+                        GROUP BY product_id, inventory_location_id
+                    )
+                ) s ON l.id = s.inventory_location_id
                 LEFT JOIN products p ON s.product_id = p.id
                 WHERE l.warehouse_id = ?
                 GROUP BY l.id, l.storage_id
@@ -40,12 +48,16 @@ class Api::V1::InventoryLocationsController < ApplicationController
             FROM inventory_summaries s
             JOIN products p ON s.product_id = p.id
             JOIN inventory_statuses st ON s.inventory_status_id = st.id
-            WHERE s.inventory_location_id = ?
+            WHERE s.id IN (
+                SELECT MAX(id)
+                FROM inventory_summaries
+                WHERE inventory_location_id = ?
+                GROUP BY product_id
+            )
         SQL
         @inventory_details = ActiveRecord::Base.connection.exec_query(
             ActiveRecord::Base.send(:sanitize_sql_array, [ sql, @location.id ])
         )
-
         authorize @location
         render json: { location: @location, inventory_details: @inventory_details }, status: :ok
     rescue ActiveRecord::RecordNotFound


### PR DESCRIPTION
## fix(inventory_location): Correct and optimize inventory summary retrieval queries

Updates the SQL in the inventory location controller's `index` and `show` actions to reliably fetch the most recent (MAX(id)) inventory summary for each product/location combination.

- **Index Query:** Ensures product count and total quantity aggregates are based on the latest summary across all locations in a warehouse.
- **Show Query:** Adds a critical filter (`WHERE inventory_location_id = ?`) to the MAX(id) subquery to guarantee that only summaries relevant to the current location are retrieved.